### PR TITLE
Add missing numpy requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     ],
     include_package_data = True,
     install_requires=[
+        'numpy',
         'requests',
         'click',
         'simplejson',


### PR DESCRIPTION
I started in a fresh virtual env and had to additionally `pip install numpy` to get `kachery-cloud-init` to work.